### PR TITLE
project: Fix audiotools installation with pip > 19.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ cover/
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 .pytest_cache/
 nosetests.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,5 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-https://github.com/tuffy/python-audio-tools/tarball/v3.0#egg=audiotools-3.0
 mutagen>=1.29
 pbr

--- a/sync_music/sync_music.py
+++ b/sync_music/sync_music.py
@@ -221,8 +221,7 @@ class SyncMusic():
                             line = self._hashdb.database[in_filename][0]
                             line = line.replace('/', '\\')
                             break
-                        else:
-                            in_filename = in_filename.split('/', 1)[1]
+                        in_filename = in_filename.split('/', 1)[1]
                 except IndexError:
                     logger.warning("File does not exist: {}", line)
                     continue

--- a/sync_music/sync_music.py
+++ b/sync_music/sync_music.py
@@ -375,13 +375,13 @@ def main():  # pragma: no cover
     sync_music = SyncMusic(args)
 
     if not args.batch and not util.query_yes_no("Do you want to continue?"):
-        exit(1)
+        sys.exit(1)
 
     try:
         sync_music.sync_audio()
     except FileNotFoundError as err:
         logger.critical("Failed to sync music {}", err)
-        exit(1)
+        sys.exit(1)
 
     if args.playlist_src:
         sync_music.sync_playlists()

--- a/tox.ini
+++ b/tox.ini
@@ -21,11 +21,11 @@
 envlist = py35, py36
 
 [testenv]
-install_command = pip install --process-dependency-links -U {opts} {packages}
 deps = pytest-mock
        pytest-cov
        pytest-flake8
        pytest-pylint
+       audiotools@https://github.com/tuffy/python-audio-tools/archive/v3.1.1.zip#sha256=92ad8c00d0349698459587b69cc34113726ebeee77d37b6072214ed616324306
 commands = pytest {posargs} --flake8 --pylint --junitxml=junit-{envname}.xml \
                             --cov-config=.coveragerc --cov=sync_music \
                             --cov-report=term-missing --cov-report=html \


### PR DESCRIPTION
The --process-dependency-links option got removed in pip 19.0.
Specify the URL based dependency according to PEP 508.

Unfortunately there's still no audiotools PyPI package and the
development has stalled.

See: https://www.python.org/dev/peps/pep-0508