### PR TITLE
sync_music: Fix version info string

### DIFF
--- a/sync_music/sync_music.py
+++ b/sync_music/sync_music.py
@@ -34,7 +34,7 @@ from .actions import Copy
 from .actions import Skip
 from .transcode import Transcode
 
-__version__ = pbr.version.VersionInfo('kasserver').release_string()
+__version__ = pbr.version.VersionInfo('sync_music').release_string()
 
 logger = util.LogStyleAdapter(  # pylint: disable=invalid-name
     logging.getLogger(__name__))


### PR DESCRIPTION
I think this was a typo, but I did need this change after a `pip install sync_music`

Thanks for this tool it seems to be just what I was looking for.