### PR TITLE
tox: Fix warnings reported by PyLint 2.11.0

### DIFF
--- a/sync_music/__init__.py
+++ b/sync_music/__init__.py
@@ -29,7 +29,7 @@ def verify_interpreter_version():
     version = python_version()
     if parse_version(version) < parse_version(minversion):  # pragma: no cover
         sys.stdout.write(
-            "Incompatible Python version, minimum supported "
+            "Incompatible Python version, minimum supported "  # pylint: disable=consider-using-f-string
             "version {}, found version {}\n".format(minversion, version)
         )
         sys.exit(1)


### PR DESCRIPTION
Formatting a regular string which could be a f-string
(consider-using-f-string)