### PR TITLE
tox: Fix warnings reported by PyLint 2.11.1

### DIFF
--- a/sync_music/__main__.py
+++ b/sync_music/__main__.py
@@ -17,6 +17,6 @@
 
 """sync_music - Sync music library to external device."""  # pragma: no cover
 
-from .sync_music import main  # pragma: no cover
+from sync_music.sync_music import main  # pragma: no cover
 
 main()  # pragma: no cover


### PR DESCRIPTION
No name 'main' in module 'sync_music' (no-name-in-module)